### PR TITLE
Allow unordinary lengths for (u)ints

### DIFF
--- a/binstruct_test.go
+++ b/binstruct_test.go
@@ -88,6 +88,35 @@ func Test_IntLE(t *testing.T) {
 	require.Equal(t, want, actual)
 }
 
+func Test_IntXLE(t *testing.T) {
+	// Test the weird sizes, i.e. not powers of 2
+	data := []byte{
+		0x03, 0x00, 0xf0, // -1048573
+		0x0a, 0xfb, 0xc2, 0x10, 0xf0, // -68438263030
+		0x0a, 0xfb, 0xc2, 0x10, 0xf0, 0x0c, // 14225212898058
+		0x0a, 0xfb, 0xc2, 0x10, 0xf0, 0x0c, 0x7d, // 35198597301730058
+	}
+
+	type dataStruct struct {
+		I3 int32 `bin:"len:3"`
+		I5 int64 `bin:"len:5"`
+		I6 int64 `bin:"len:6"`
+		I7 int64 `bin:"len:7"`
+	}
+
+	want := dataStruct{
+		I3: -1048573,
+		I5: -68438263030,
+		I6: 14225212898058,
+		I7: 35198597301730058,
+	}
+
+	var actual dataStruct
+	err := UnmarshalLE(data, &actual)
+	require.NoError(t, err)
+	require.Equal(t, want, actual)
+}
+
 func Test_IntBE(t *testing.T) {
 	data := []byte{
 		0x01,
@@ -105,6 +134,35 @@ func Test_IntBE(t *testing.T) {
 
 	want := dataStruct{
 		I8: 1, I16: 2, I32: 3, I64: 4,
+	}
+
+	var actual dataStruct
+	err := UnmarshalBE(data, &actual)
+	require.NoError(t, err)
+	require.Equal(t, want, actual)
+}
+
+func Test_IntXBE(t *testing.T) {
+	// Test the weird sizes, i.e. not powers of 2
+	data := []byte{
+		0xf0, 0x00, 0x03, // -1048573
+		0xf0, 0x10, 0xc2, 0xfb, 0x0a, // -68438263030
+		0x0c, 0xf0, 0x10, 0xc2, 0xfb, 0x0a, // 14225212898058
+		0x7d, 0x0c, 0xf0, 0x10, 0xc2, 0xfb, 0x0a, // 35198597301730058
+	}
+
+	type dataStruct struct {
+		I3 int32 `bin:"len:3"`
+		I5 int64 `bin:"len:5"`
+		I6 int64 `bin:"len:6"`
+		I7 int64 `bin:"len:7"`
+	}
+
+	want := dataStruct{
+		I3: -1048573,
+		I5: -68438263030,
+		I6: 14225212898058,
+		I7: 35198597301730058,
 	}
 
 	var actual dataStruct

--- a/binstruct_test.go
+++ b/binstruct_test.go
@@ -91,10 +91,10 @@ func Test_IntLE(t *testing.T) {
 func Test_IntXLE(t *testing.T) {
 	// Test the weird sizes, i.e. not powers of 2
 	data := []byte{
-		0x03, 0x00, 0xf0, // -1048573
-		0x0a, 0xfb, 0xc2, 0x10, 0xf0, // -68438263030
-		0x0a, 0xfb, 0xc2, 0x10, 0xf0, 0x0c, // 14225212898058
-		0x0a, 0xfb, 0xc2, 0x10, 0xf0, 0x0c, 0x7d, // 35198597301730058
+		0x03, 0x00, 0xf0,
+		0x0a, 0xfb, 0xc2, 0x10, 0xf0,
+		0x0a, 0xfb, 0xc2, 0x10, 0xf0, 0x0c,
+		0x0a, 0xfb, 0xc2, 0x10, 0xf0, 0x0c, 0x7d,
 	}
 
 	type dataStruct struct {
@@ -145,10 +145,10 @@ func Test_IntBE(t *testing.T) {
 func Test_IntXBE(t *testing.T) {
 	// Test the weird sizes, i.e. not powers of 2
 	data := []byte{
-		0xf0, 0x00, 0x03, // -1048573
-		0xf0, 0x10, 0xc2, 0xfb, 0x0a, // -68438263030
-		0x0c, 0xf0, 0x10, 0xc2, 0xfb, 0x0a, // 14225212898058
-		0x7d, 0x0c, 0xf0, 0x10, 0xc2, 0xfb, 0x0a, // 35198597301730058
+		0xf0, 0x00, 0x03,
+		0xf0, 0x10, 0xc2, 0xfb, 0x0a,
+		0x0c, 0xf0, 0x10, 0xc2, 0xfb, 0x0a,
+		0x7d, 0x0c, 0xf0, 0x10, 0xc2, 0xfb, 0x0a,
 	}
 
 	type dataStruct struct {
@@ -211,6 +211,60 @@ func Test_IntBEWithoutLenTag(t *testing.T) {
 	require.Equal(t, dataStruct{}, actual)
 }
 
+func Test_UIntLE(t *testing.T) {
+	data := []byte{
+		0x01,
+		0x02, 0x00,
+		0x03, 0x00, 0x00, 0x00,
+		0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}
+
+	type dataStruct struct {
+		I8  uint8
+		I16 uint16
+		I32 uint32
+		I64 uint64
+	}
+
+	want := dataStruct{
+		I8: 1, I16: 2, I32: 3, I64: 4,
+	}
+
+	var actual dataStruct
+	err := UnmarshalLE(data, &actual)
+	require.NoError(t, err)
+	require.Equal(t, want, actual)
+}
+
+func Test_UIntXLE(t *testing.T) {
+	// Test the weird sizes, i.e. not powers of 2
+	data := []byte{
+		0x03, 0x00, 0xf0,
+		0x0a, 0xfb, 0xc2, 0x10, 0xf0,
+		0x0a, 0xfb, 0xc2, 0x10, 0xf0, 0x0c,
+		0x0a, 0xfb, 0xc2, 0x10, 0xf0, 0x0c, 0x7d,
+	}
+
+	type dataStruct struct {
+		I3 uint32 `bin:"len:3"`
+		I5 uint64 `bin:"len:5"`
+		I6 uint64 `bin:"len:6"`
+		I7 uint64 `bin:"len:7"`
+	}
+
+	want := dataStruct{
+		I3: 15728643,
+		I5: 1031073364746,
+		I6: 14225212898058,
+		I7: 35198597301730058,
+	}
+
+	var actual dataStruct
+	err := UnmarshalLE(data, &actual)
+	require.NoError(t, err)
+	require.Equal(t, want, actual)
+}
+
 func Test_UintBE(t *testing.T) {
 	data := []byte{
 		0x01,
@@ -228,6 +282,35 @@ func Test_UintBE(t *testing.T) {
 
 	want := dataStruct{
 		I8: 1, I16: 2, I32: 3, I64: 4,
+	}
+
+	var actual dataStruct
+	err := UnmarshalBE(data, &actual)
+	require.NoError(t, err)
+	require.Equal(t, want, actual)
+}
+
+func Test_UIntXBE(t *testing.T) {
+	// Test the weird sizes, i.e. not powers of 2
+	data := []byte{
+		0xf0, 0x00, 0x03,
+		0xf0, 0x10, 0xc2, 0xfb, 0x0a,
+		0x0c, 0xf0, 0x10, 0xc2, 0xfb, 0x0a,
+		0x7d, 0x0c, 0xf0, 0x10, 0xc2, 0xfb, 0x0a,
+	}
+
+	type dataStruct struct {
+		I3 uint32 `bin:"len:3"`
+		I5 uint64 `bin:"len:5"`
+		I6 uint64 `bin:"len:6"`
+		I7 uint64 `bin:"len:7"`
+	}
+
+	want := dataStruct{
+		I3: 15728643,
+		I5: 1031073364746,
+		I6: 14225212898058,
+		I7: 35198597301730058,
 	}
 
 	var actual dataStruct

--- a/reader.go
+++ b/reader.go
@@ -172,7 +172,7 @@ func (r *reader) ReadUint64() (uint64, error) {
 }
 
 func (r *reader) ReadUintX(x int) (uint64, error) {
-	var i uint64
+	var i uint64 = 0
 	var err error
 
 	if x > 8 {
@@ -181,7 +181,18 @@ func (r *reader) ReadUintX(x int) (uint64, error) {
 
 	_, b, err := r.ReadBytes(x)
 
-	i = r.order.Uint64(append(make([]byte, 8-x), b...))
+	if r.order == binary.BigEndian {
+		for j := 0; j < x; j++ {
+			i |= uint64(b[j]) << (8 * (x - j - 1))
+		}
+	} else if r.order == binary.LittleEndian {
+		for j := 0; j < x; j++ {
+			i |= uint64(b[x-j-1]) << (8 * (x - j - 1))
+		}
+	} else {
+		err = errors.New("cannot determine endianness for custom (u)int length read")
+	}
+
 	return i, err
 }
 

--- a/reader.go
+++ b/reader.go
@@ -42,6 +42,8 @@ type Reader interface {
 	ReadUint32() (uint32, error)
 	// ReadUint64 read eight bytes and return uint64 value
 	ReadUint64() (uint64, error)
+	// ReadUintX read X bytes and return uint64 value
+	ReadUintX(x int) (uint64, error)
 
 	// ReadInt8 read one byte and return int8 value
 	ReadInt8() (int8, error)
@@ -51,6 +53,8 @@ type Reader interface {
 	ReadInt32() (int32, error)
 	// ReadInt64 read eight bytes and return int64 value
 	ReadInt64() (int64, error)
+	// ReadIntX read X bytes and return int64 value
+	ReadIntX(x int) (int64, error)
 
 	// ReadFloat32 read four bytes and return float32 value
 	ReadFloat32() (float32, error)
@@ -167,6 +171,20 @@ func (r *reader) ReadUint64() (uint64, error) {
 	return r.order.Uint64(b), nil
 }
 
+func (r *reader) ReadUintX(x int) (uint64, error) {
+	var i uint64
+	var err error
+
+	if x > 8 {
+		err = errors.New("cannot read more than 8 bytes for custom length (u)int")
+	}
+
+	_, b, err := r.ReadBytes(x)
+
+	i = r.order.Uint64(append(make([]byte, 8-x), b...))
+	return i, err
+}
+
 func (r *reader) ReadInt8() (int8, error) {
 	i, err := r.ReadUint8()
 	return int8(i), err
@@ -184,6 +202,16 @@ func (r *reader) ReadInt32() (int32, error) {
 
 func (r *reader) ReadInt64() (int64, error) {
 	i, err := r.ReadUint64()
+	return int64(i), err
+}
+
+func (r *reader) ReadIntX(x int) (int64, error) {
+	u, err := r.ReadUintX(x)
+
+	// Properly handle negatives by shifting fully left and then right
+	u = u << (64 - 8*x)
+	i := int64(u) >> (64 - 8*x)
+
 	return int64(i), err
 }
 

--- a/reader.go
+++ b/reader.go
@@ -189,11 +189,11 @@ func (r *reader) ReadUintX(x int) (uint64, error) {
 
 	if r.order == binary.BigEndian {
 		for j := 0; j < x; j++ {
-			i |= uint64(b[j]) << (8 * (x - j - 1))
+			i |= uint64(b[x-j-1]) << (8 * j)
 		}
 	} else if r.order == binary.LittleEndian {
 		for j := 0; j < x; j++ {
-			i |= uint64(b[x-j-1]) << (8 * (x - j - 1))
+			i |= uint64(b[j]) << (8 * j)
 		}
 	} else {
 		err = errors.New("cannot determine endianness for custom (u)int length read")

--- a/reader.go
+++ b/reader.go
@@ -177,9 +177,15 @@ func (r *reader) ReadUintX(x int) (uint64, error) {
 
 	if x > 8 {
 		err = errors.New("cannot read more than 8 bytes for custom length (u)int")
+		return i, err
 	}
 
-	_, b, err := r.ReadBytes(x)
+	n, b, err := r.ReadBytes(x)
+
+	if n != x || err != nil {
+		err = errors.New(fmt.Sprintf("failed to read custom (u)int length: got %d instead of %d", n, x))
+		return i, err
+	}
 
 	if r.order == binary.BigEndian {
 		for j := 0; j < x; j++ {

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -124,25 +124,33 @@ or
 	switch fieldValue.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		var value int64
+		var err error
 
-		switch {
-		case fieldData.Length != nil && *fieldData.Length == 1 || fieldValue.Kind() == reflect.Int8:
-			v, e := r.ReadInt8()
-			value = int64(v)
-			err = e
-		case fieldData.Length != nil && *fieldData.Length == 2 || fieldValue.Kind() == reflect.Int16:
-			v, e := r.ReadInt16()
-			value = int64(v)
-			err = e
-		case fieldData.Length != nil && *fieldData.Length == 4 || fieldValue.Kind() == reflect.Int32:
-			v, e := r.ReadInt32()
-			value = int64(v)
-			err = e
-		case fieldData.Length != nil && *fieldData.Length == 8 || fieldValue.Kind() == reflect.Int64:
-			value, err = r.ReadInt64()
-		default: // reflect.Int:
-			err = errors.New("need set tag with len or use int8/int16/int32/int64")
+		if fieldData.Length != nil {
+			value, err = r.ReadIntX(int(*fieldData.Length))
+		} else {
+			switch fieldValue.Kind() {
+			case reflect.Int8:
+				v, e := r.ReadInt8()
+				value = int64(v)
+				err = e
+			case reflect.Int16:
+				v, e := r.ReadInt16()
+				value = int64(v)
+				err = e
+			case reflect.Int32:
+				v, e := r.ReadInt32()
+				value = int64(v)
+				err = e
+			case reflect.Int64:
+				v, e := r.ReadInt64()
+				value = v
+				err = e
+			default: // reflect.Int:
+				return errors.New("need set tag with len or use int8/int16/int32/int64")
+			}
 		}
+
 		if err != nil {
 			return err
 		}
@@ -152,25 +160,33 @@ or
 		}
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		var value uint64
+		var err error
 
-		switch {
-		case fieldData.Length != nil && *fieldData.Length == 1 || fieldValue.Kind() == reflect.Uint8:
-			v, e := r.ReadUint8()
-			value = uint64(v)
-			err = e
-		case fieldData.Length != nil && *fieldData.Length == 2 || fieldValue.Kind() == reflect.Uint16:
-			v, e := r.ReadUint16()
-			value = uint64(v)
-			err = e
-		case fieldData.Length != nil && *fieldData.Length == 4 || fieldValue.Kind() == reflect.Uint32:
-			v, e := r.ReadUint32()
-			value = uint64(v)
-			err = e
-		case fieldData.Length != nil && *fieldData.Length == 8 || fieldValue.Kind() == reflect.Uint64:
-			value, err = r.ReadUint64()
-		default: // reflect.Uint:
-			err = errors.New("need set tag with len or use uint8/uint16/uint32/uint64")
+		if fieldData.Length != nil {
+			value, err = r.ReadUintX(int(*fieldData.Length))
+		} else {
+			switch fieldValue.Kind() {
+			case reflect.Uint8:
+				v, e := r.ReadUint8()
+				value = uint64(v)
+				err = e
+			case reflect.Uint16:
+				v, e := r.ReadUint16()
+				value = uint64(v)
+				err = e
+			case reflect.Uint32:
+				v, e := r.ReadUint32()
+				value = uint64(v)
+				err = e
+			case reflect.Uint64:
+				v, e := r.ReadUint64()
+				value = v
+				err = e
+			default: // reflect.Uint:
+				return errors.New("need set tag with len or use uint8/uint16/uint32/uint64")
+			}
 		}
+
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Currently, only lengths that are a power of two are correctly read from bytes. Other cases fail due to being forced into reading the number of bytes of the target field.

For example:

```go
type Foo struct {
    Prefix  int32 `bin:"len:3"`
    Version uint8
}
```

This struct should read 3 bytes and interpret them as an "int24" - the 24th bit should be the indicator of negativity - and store that value in an int32. Currently, because `len` is not a power of two in this example, readers will look to the type of the target field and determine that 4 bytes should be read and interpreted as an int32.

This pull request addresses this issue by using a variable length reader/interpreter for these cases. When `len` is provided, exactly that number of bytes are interpreted. First they are ingested by iterative bit shifting and ORing. In the `int` cases, the value is byte shifted left as a `uint`, then cast as an `int` and shifted right to account for negativity via twos-complement shifting rules.