### PR TITLE
Update min Go version to 1.21.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/ghostiam/binstruct
 
-go 1.13
+go 1.21
 
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/stretchr/testify v1.3.0
 )
+
+require github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/reader.go
+++ b/reader.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 )
 
@@ -93,7 +92,7 @@ type reader struct {
 }
 
 func (r *reader) ReadAll() ([]byte, error) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 
 	if r.debug {
 		fmt.Printf("ReadAll(): %s", hex.Dump(b))


### PR DESCRIPTION
Per the release policy [1], versions earlier than Go 1.21 are
no longer supported now that 1.23 has been released.

Also remove deprecated usage of ioutil.

[1] https://go.dev/doc/devel/release#policy
